### PR TITLE
Rewrite LVM Code to libblockdev 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,14 @@ Getting Started
 ---------------
 targetd has these Python library dependencies:
 * [python-rtslib](https://github.com/agrover/rtslib-fb) 2.1.fb42+  (must be fb*)
-* [LVM2 with Python bindings(lvm2-python-libs)](https://sourceware.org/lvm2/) 2.02.99+
+* [libblockdev](https://github.com/storaged-project/libblockdev)
+* `python3-blockdev`
+* `libblockdev-lvm-dbus` and `lvm2-dbusd` (to use the DBus API **recommended**) **or** 
+* `libblockdev-lvm`  to use the lvm binary API
 * [python-setproctitle](https://github.com/dvarrazzo/py-setproctitle)
 * [PyYAML](http://pyyaml.org/)
 
-All of these are available in Fedora Rawhide.
+All of these are available in Fedora Rawhide and recent Ubuntu versions.
 
 ### Configuring targetd
 
@@ -60,7 +63,7 @@ an example:
 
     block_pools: [vg-targetd/thin_pool, vg-targetd-too/thin_pool]
     fs_pools: [/mnt/btrfs]
-
+    
 targetd defaults to using the "vg-targetd/thin_pool" volume group and thin
 pool logical volume, and username 'admin'. The admin password does not have a
 default -- each installation must set it.

--- a/targetd/utils.py
+++ b/targetd/utils.py
@@ -46,6 +46,7 @@ class TargetdError(Exception):
     NO_FREE_HOST_LUN_ID = -1000
     NOT_FOUND_ACCESS_GROUP = -200
     VOLUME_MASKED = -303
+    VOLUME_GROUP_NOT_FOUND = -152
 
     def __init__(self, error_code, *args, **kwargs):
         Exception.__init__(self, *args, **kwargs)


### PR DESCRIPTION
This PR removes the deprecated lvm python bindings and replaces them with bindings from `libblockdev` which uses the more modern DBus API or even the binaries. It also officially deprecates the FS API which depends on BTRFS which itself is deprecated. The FS API will continue to function as it used to but is unmaintained may break at any time. A warning is logged if this API is used. 

This PR ~~is a **placeholder** and~~ should be **held** pending ~~further testing~~, feedback, and eventual squashing of the commits. 