### PR TITLE
Add Configuration Option for Portal Addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,15 @@ an example:
     block_pools: [vg-targetd/thin_pool, vg-targetd-too/thin_pool]
     fs_pools: [/mnt/btrfs]
     
+    portal_addresses: ["192.168.0.10"]
+    
 targetd defaults to using the "vg-targetd/thin_pool" volume group and thin
 pool logical volume, and username 'admin'. The admin password does not have a
-default -- each installation must set it.
+default -- each installation must set it. Use the portal_addresses parameter to set 
+explicit addresses that LIO should direct iSCSI connections to, this is 
+useful if you are using a proxy such that LIO cannot correctly detect the
+public address (e.g. a Kubernetes service). The default behavior is to listen
+on all addresses (0.0.0.0).
 
 Then, in the root of the source directory, do the following as root:
 ```bash

--- a/targetd/block.py
+++ b/targetd/block.py
@@ -73,6 +73,11 @@ def pool_check(pool_name):
         raise TargetdError(TargetdError.INVALID_POOL, "Invalid pool")
 
 
+def set_portal_addresses(tpg):
+    for a in addresses:
+        NetworkPortal(tpg, a)
+
+
 pools = []
 target_name = ""
 addresses = []
@@ -253,8 +258,7 @@ def export_create(req, pool, vol, initiator_wwn, lun):
     tpg.enable = True
     tpg.set_attribute("authentication", '0')
 
-    for a in addresses:
-        NetworkPortal(tpg, a)
+    set_portal_addresses(tpg)
 
     na = NodeACL(tpg, initiator_wwn)
 
@@ -594,7 +598,8 @@ def access_group_map_create(req, pool_name, vol_name, ag_name, h_lun_id=None):
     tpg = _get_iscsi_tpg()
     tpg.enable = True
     tpg.set_attribute("authentication", '0')
-    NetworkPortal(tpg, "0.0.0.0")
+
+    set_portal_addresses(tpg)
 
     tpg_lun = _tpg_lun_of(tpg, pool_name, vol_name)
 

--- a/targetd/block.py
+++ b/targetd/block.py
@@ -75,6 +75,7 @@ def pool_check(pool_name):
 
 pools = []
 target_name = ""
+addresses = []
 
 
 #
@@ -87,6 +88,9 @@ def initialize(config_dict):
 
     global target_name
     target_name = config_dict['target_name']
+
+    global addresses
+    addresses = config_dict['portal_addresses']
 
     # fail early if can't access any vg
     for pool in pools:
@@ -243,13 +247,15 @@ def export_list(req):
 
 
 def export_create(req, pool, vol, initiator_wwn, lun):
-
     fm = FabricModule('iscsi')
     t = Target(fm, target_name)
     tpg = TPG(t, 1)
     tpg.enable = True
     tpg.set_attribute("authentication", '0')
-    NetworkPortal(tpg, "0.0.0.0")
+
+    for a in addresses:
+        NetworkPortal(tpg, a)
+
     na = NodeACL(tpg, initiator_wwn)
 
     tpg_lun = _tpg_lun_of(tpg, pool, vol)

--- a/targetd/main.py
+++ b/targetd/main.py
@@ -47,6 +47,7 @@ default_config = dict(
     ssl=False,
     ssl_cert="/etc/target/targetd_cert.pem",
     ssl_key="/etc/target/targetd_key.pem",
+    portal_addresses=["0.0.0.0"]
 )
 
 config = {}


### PR DESCRIPTION
As discussed in #30 if targetd is running in a container environment or behind a proxy then it could report an incorrect address to clients.

This is a little different than what we had originally discussed, since when I started working on this I realized that the addresses are not set per-export but are rather system wide I decided to go with an addition to the config file instead. This makes it easier for me, since i wont have to modify the provisioner to call the new API, it keeps your API stable, and overall it makes more sense.