### PR TITLE
Add missing pip3 package

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,7 @@ RUN apk update && \
     apk add \
         python3 \
         python3-dev \
+        py3-pip \
         py3-gobject3 \
         libblockdev-dev \
         py3-libblockdev \


### PR DESCRIPTION
Dockerfile uses pip3 to install python package, but it's missing.
This patch adds py3-pip using apk.