### PR TITLE
Copy method on ZFS pools

### DIFF
--- a/targetd.yaml.5
+++ b/targetd.yaml.5
@@ -37,6 +37,13 @@ relationship, like "tank/ds" and "tank/ds/ds2".
 Using ZFS requires zfs binary to be accessible.
 Cannot contain colons even though it's supported by ZFS itself.
 
+.B zfs_enable_copy
+.br
+Enables copy method on ZFS volumes.
+.B Warning:
+copying ZFS volumes will make source volumes unable to be deleted
+as long as copies exist. This is due to ZFS snapshot/clone limitations.
+
 .B fs_pools
 .br
 Sets the mount point(s) that targetd will use to export filesystems

--- a/targetd/backends/lvm.py
+++ b/targetd/backends/lvm.py
@@ -121,7 +121,7 @@ def get_dev_path(pool_name, vol_name):
     return "/dev/%s/%s" % (pool2dev_name(pool_name), vol_name)
 
 
-def initialize(init_pools):
+def initialize(config_dict, init_pools):
     global pools
     check_pools_access(init_pools)
     pools = init_pools

--- a/targetd/block.py
+++ b/targetd/block.py
@@ -93,7 +93,7 @@ def initialize(config_dict):
 
     # initialize and check both pools
     for modname, mod in pool_modules.items():
-        mod.initialize(pools[modname])
+        mod.initialize(config_dict, pools[modname])
 
     return dict(
         vol_list=volumes,

--- a/targetd/main.py
+++ b/targetd/main.py
@@ -40,6 +40,7 @@ default_config = dict(
     block_pools=['vg-targetd'],
     fs_pools=[],
     zfs_block_pools=[],
+    zfs_enable_copy=False,
     user="admin",
     log_level='info',
     # security: no default password

--- a/test/targetd.yaml
+++ b/test/targetd.yaml
@@ -3,4 +3,5 @@ target_name: iqn.2003-01.org.example.mach1:1234
 log_level: debug
 block_pools: [vg-targetd/thin_pool]
 zfs_block_pools: [zfs_targetd]
+zfs_enable_copy: true
 fs_pools: [/mnt/btrfs]


### PR DESCRIPTION
Refs #47

This method works, however there is limitation when using zfs snapshot
and clone: clone is dependant on original dataset and it's snapshot
and ZFS does not offer any way around that (zfs promote allows to
switch parent-child relationship, but doesn't break it).

So, when user creates copy the source dataset cannot be destroyed
as long as copies exist.

This may be surprising and not desired behavior for the end user,
but there is no viable way to remedy this (except using zfs send | zfs recv
instead, but this is long operation and involves copying all data on dataset).

Because of that I was thinking about making a flag in config to enable
copy method on ZFS, so user will be aware of consequences and limitations.

@tasleson What do you think about that?


