### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,6 @@ setup(
     maintainer='Andy Grover',
     maintainer_email='andy@groveronline.com',
     url='http://github.com/open-iscsi/targetd',
-    packages=['targetd'],
+    packages=['targetd','targetd.backends'],
     install_requires=['setproctitle', 'yaml', 'rtslib_fb'],
     scripts=['scripts/targetd'])


### PR DESCRIPTION
Add the backends package now that there is one after the ZFS support was included. ArchLinux AUR package relies on setup.py to do most of the heavy lifting and as such currently fails with the latest 0.8.12 release due to the missing "targetd.backends" package.