### PR TITLE
ZFS FS support (for NFS exports)

### DIFF
--- a/API.md
+++ b/API.md
@@ -250,7 +250,7 @@ Errors:
 File system operations
 ----------------------
 Ability to create different file systems and perform operation on them.  The
-pool is a btrfs sub volume and new file systems are sub volumes within that
+pool is a btrfs or ZFS sub volume and new file systems are sub volumes within that
 sub volume.
 
 ### fs_list()

--- a/client
+++ b/client
@@ -48,7 +48,7 @@ path = '/targetrpc'
 id_num = 1
 ssl = False
 pools = ['vg-targetd/thin_pool','zfs_targetd/block_pool']
-fs_pools = ['/mnt/btrfs','zfs_targetd/fs_pool']
+fs_pools = ['/mnt/btrfs','/zfs_targetd/fs_pool']
 
 def jsonrequest(method, params=None):
     print("%s %s" % ("+" * 20, method))

--- a/client
+++ b/client
@@ -48,7 +48,7 @@ path = '/targetrpc'
 id_num = 1
 ssl = False
 pool = 'vg-targetd/thin_pool'
-
+fs_pools = ['/mnt/btrfs','zfs_targetd/fs_pool']
 
 def jsonrequest(method, params=None):
     print("%s %s" % ("+" * 20, method))
@@ -150,3 +150,79 @@ try:
 finally:
     jsonrequest("vol_destroy", dict(pool=pool, name="test2"))
     print("done")
+
+failed = False
+# ZFS fs tests
+for fs_pool in fs_pools:
+    fs_uuid = None
+
+    print("testing {0}".format(fs_pool))
+    try:
+        jsonrequest('fs_create', dict(pool_name=fs_pool, name="test-fs", size_bytes=0))
+
+        results = jsonrequest('fs_list')
+        for fs in results:
+            print("{pool}: {uuid} -> {name}".format(**fs))
+            if fs['pool'] != fs_pool:
+                failed = True
+                raise Exception("unrecognized pool filesystem")
+            fs_uuid = fs['uuid']
+
+            ss_uuid = None
+
+            try:
+                jsonrequest('fs_snapshot', dict(fs_uuid=fs_uuid, dest_ss_name="test-snapshot"))
+
+                ss_results = jsonrequest('ss_list', dict(fs_uuid=fs_uuid))
+
+                has_snapshot = False
+                for ss in ss_results:
+                    print("{uuid} -> {name} ({timestamp})".format(**ss))
+                    if ss['name'] != "test-snapshot":
+                        failed = True
+                        raise Exception("unrecognized snapshot")
+
+                    ss_uuid = ss['uuid']
+                    has_snapshot = True
+
+                    clone_uuid = None
+
+                    try:
+                        jsonrequest("fs_clone", dict(fs_uuid=fs_uuid, dest_fs_name="test-clone", snapshot_id=ss_uuid))
+
+                        clone_results = jsonrequest('fs_list')
+
+                        has_clone = False
+                        for result in clone_results:
+                            print("{pool}: {uuid} -> {name}".format(**result))
+                            if result['name'] == 'test-clone':
+                                clone_uuid = result['uuid']
+                                has_clone = True
+                        if not has_clone:
+                            failed = True
+                            raise Exception("test-clone not found")
+                    finally:
+                        if clone_uuid is not None:
+                            jsonrequest("fs_destroy",dict(uuid=clone_uuid))
+
+                if not has_snapshot:
+                    failed = True
+                    raise Exception("test-snapshot not found")
+
+            finally:
+                if ss_uuid is not None:
+                    jsonrequest("fs_snapshot_delete", dict(fs_uuid=fs_uuid, ss_uuid=ss_uuid))
+    finally:
+        if fs_uuid is not None:
+            jsonrequest("fs_destroy", dict(uuid=fs_uuid))
+
+    print("fs'es left over:")
+    results = jsonrequest("fs_list")
+    for fs in results:
+        print("{pool}: {uuid} -> {name}".format(**fs))
+        # No filesystems should be left
+        failed = True
+
+    if failed:
+        print("Test failed")
+        exit(1)

--- a/client
+++ b/client
@@ -47,7 +47,7 @@ port = 18700
 path = '/targetrpc'
 id_num = 1
 ssl = False
-pool = 'vg-targetd/thin_pool'
+pools = ['vg-targetd/thin_pool','zfs_targetd/block_pool']
 fs_pools = ['/mnt/btrfs','zfs_targetd/fs_pool']
 
 def jsonrequest(method, params=None):
@@ -103,60 +103,74 @@ for result in results:
     print("pool %s %s %s" % (str(result['name']), str(result['size']),
                              str(result['free_size'])))
 
-results = jsonrequest("vol_list", dict(pool=pool))
-for result in results:
-    print("vol %s %s %s" % (str(result['name']), str(result['size']),
-                            str(result['uuid'])))
-
 #sys.exit(1)
+failed = False
 
-try:
-    jsonrequest('vol_create', dict(pool=pool, name="test2", size=4000000))
+for pool in pools:
+    print("Testing block pool: {0}".format(pool))
+
+    results = jsonrequest("vol_list", dict(pool=pool))
+    for result in results:
+        print("vol %s %s %s" % (str(result['name']), str(result['size']),
+                                str(result['uuid'])))
 
     try:
-        jsonrequest("vol_copy",
-                    dict(pool=pool, vol_orig="test2", vol_new="test2-copy"))
+        jsonrequest('vol_create', dict(pool=pool, name="test2", size=4*1024*1024))
 
         try:
-            jsonrequest("export_create",
-                        dict(
-                            pool=pool,
-                            vol="test2",
-                            lun=5,
-                            initiator_wwn="iqn.2006-03.com.wtf.ohyeah:666"))
+            jsonrequest("vol_copy",
+                        dict(pool=pool, vol_orig="test2", vol_new="test2-copy"))
 
-            print("waiting")
-            time.sleep(5)
-            results = jsonrequest("export_list")
-            for result in results:
-                print("export %s %s %s %s %s" % (str(result['initiator_wwn']),
-                                                 str(result['pool']),
-                                                 str(result['vol_name']),
-                                                 str(result['lun']),
-                                                 str(result['vol_uuid'])))
-            time.sleep(5)
-            print("go!")
+            try:
+                jsonrequest("export_create",
+                            dict(
+                                pool=pool,
+                                vol="test2",
+                                lun=5,
+                                initiator_wwn="iqn.2006-03.com.wtf.ohyeah:666"))
+
+                print("waiting")
+                time.sleep(5)
+                results = jsonrequest("export_list")
+                for result in results:
+                    print("export %s %s %s %s %s" % (str(result['initiator_wwn']),
+                                                     str(result['pool']),
+                                                     str(result['vol_name']),
+                                                     str(result['lun']),
+                                                     str(result['vol_uuid'])))
+                time.sleep(5)
+                print("go!")
+
+            finally:
+                jsonrequest("export_destroy",
+                            dict(
+                                pool=pool,
+                                vol="test2",
+                                initiator_wwn="iqn.2006-03.com.wtf.ohyeah:666"))
 
         finally:
-            jsonrequest("export_destroy",
-                        dict(
-                            pool=pool,
-                            vol="test2",
-                            initiator_wwn="iqn.2006-03.com.wtf.ohyeah:666"))
+            jsonrequest("vol_destroy", dict(pool=pool, name="test2-copy"))
 
     finally:
-        jsonrequest("vol_destroy", dict(pool=pool, name="test2-copy"))
+        jsonrequest("vol_destroy", dict(pool=pool, name="test2"))
+        print("done")
 
-finally:
-    jsonrequest("vol_destroy", dict(pool=pool, name="test2"))
-    print("done")
+    print("block volumes left over:")
+    results = jsonrequest("vol_list", dict(pool=pool))
+    for fs in results:
+        print("{pool}: {uuid} -> {name}".format(**fs))
+        # No filesystems should be left
+        failed = True
 
-failed = False
+    if failed:
+        print("Test failed")
+        exit(1)
+
 # ZFS fs tests
 for fs_pool in fs_pools:
     fs_uuid = None
 
-    print("testing {0}".format(fs_pool))
+    print("Testing FS Pool {0}".format(fs_pool))
     try:
         jsonrequest('fs_create', dict(pool_name=fs_pool, name="test-fs", size_bytes=0))
 

--- a/targetd/backends/btrfs.py
+++ b/targetd/backends/btrfs.py
@@ -49,7 +49,7 @@ pools = []
 def fs_initialize(config_dict, init_pools):
 
     global pools
-    pools = init_pools
+    pools = [fs['mount'] for fs in init_pools]
 
     for pool in pools:
         # Make sure we have the appropriate subvolumes available

--- a/targetd/backends/btrfs.py
+++ b/targetd/backends/btrfs.py
@@ -1,0 +1,272 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Copyright 2012, Andy Grover <agrover@redhat.com>
+# Copyright 2013, Tony Asleson <tasleson@redhat.com>
+#
+# fs support using btrfs.
+
+import os
+import time
+from targetd.utils import invoke, TargetdError
+
+# Notes:
+#
+# User can configure block pools (lvm volume groups) 1 to many or 0-many file
+# system mount points to be used as pools.  At this time you have to specify
+# a block pool for block operations and file system mount point pool for FS
+# operations.  We could use files on a file system for block too and create
+# file systems on top of lvm too, but that is TBD.
+#
+# We are using btrfs to provide all the cool fast FS features.  User supplies a
+# btrfs mount point and we create a targetd_fs and targetd_ss subvolumes.  Each
+# time the user creates a file system we are creating a subvolume under fs.
+# Each time a FS clone is made we create the clone under fs.  For each snapshot
+# (RO clone) we are creating a read only snapshot in
+# <mount>/targetd_ss/<fsname>/<snapshot name>
+#
+# There may be better ways of utilizing btrfs.
+
+import logging as log
+
+fs_path = "targetd_fs"
+ss_path = "targetd_ss"
+fs_cmd = 'btrfs'
+
+pools = []
+
+
+def fs_initialize(config_dict, init_pools):
+
+    global pools
+    pools = init_pools
+
+    for pool in pools:
+        # Make sure we have the appropriate subvolumes available
+        try:
+            create_sub_volume(os.path.join(pool, fs_path))
+            create_sub_volume(os.path.join(pool, ss_path))
+        except TargetdError as e:
+            log.error('Unable to create required subvolumes {0} (Btrfs)'.format(e))
+            raise
+
+
+def create_sub_volume(p):
+    if not os.path.exists(p):
+        invoke([fs_cmd, 'subvolume', 'create', p])
+
+
+def split_stdout(out):
+    """
+    Split the text out as an array of text arrays.
+    """
+    strip_it = '<FS_TREE>/'
+
+    rc = []
+    for line in out.split('\n'):
+        elem = line.split(' ')
+        if len(elem) > 1:
+            tmp = []
+            for z in elem:
+                if z.startswith(strip_it):
+                    tmp.append(z[len(strip_it):])
+                else:
+                    tmp.append(z)
+            rc.append(tmp)
+    return rc
+
+
+def fs_space_values(mount_point):
+    """
+    Return a tuple (total, free) from the specified path
+    """
+    st = os.statvfs(mount_point)
+    free = (st.f_bavail * st.f_frsize)
+    total = (st.f_blocks * st.f_frsize)
+    return total, free
+
+
+def pool_check(pool_name):
+    """
+    pool_name *cannot* be trusted, funcs taking a pool param must call
+    this or to ensure passed-in pool name is one targetd has
+    been configured to use.
+    """
+    if pool_name not in pools:
+        raise TargetdError(TargetdError.INVALID_POOL,
+                           "Invalid filesystem pool (Btrfs)")
+
+
+def has_fs_pool(pool_name):
+    """
+        This can be used to check if module owns given fs_pool without raising
+        exception
+    """
+    return pool_name in pools
+
+
+def fs_create(req, pool_name, name, size_bytes):
+    pool_check(pool_name)
+
+    full_path = os.path.join(pool_name, fs_path, name)
+
+    if not os.path.exists(full_path):
+        invoke([fs_cmd, 'subvolume', 'create', full_path])
+    else:
+        raise TargetdError(TargetdError.EXISTS_FS_NAME, 'FS already exists (Btrfs)')
+
+
+def fs_snapshot(req, pool, name, dest_ss_name):
+    source_path = os.path.join(pool, fs_path, name)
+    dest_base = os.path.join(pool, ss_path, name)
+    dest_path = os.path.join(dest_base, dest_ss_name)
+
+    create_sub_volume(dest_base)
+
+    if os.path.exists(dest_path):
+        raise TargetdError(TargetdError.EXISTS_FS_NAME,
+                           "Snapshot already exists with that name (Btrfs)")
+
+    invoke([fs_cmd, 'subvolume', 'snapshot', '-r', source_path, dest_path])
+
+
+def fs_snapshot_delete(req, pool, name, ss_name):
+    path = os.path.join(pool, ss_path, name,
+                        ss_name)
+    fs_subvolume_delete(path)
+
+
+def fs_subvolume_delete(path):
+    invoke([fs_cmd, 'subvolume', 'delete', path])
+
+
+def fs_destroy(req, pool, name):
+    # Check to see if this file system has any read-only snapshots, if yes then
+    # delete.  The API requires a FS to list its RO copies, we may want to
+    # reconsider this decision.
+
+    base_snapshot_dir = os.path.join(pool, ss_path, name)
+
+    snapshots = ss(req, pool, name)
+    for s in snapshots:
+        fs_subvolume_delete(os.path.join(base_snapshot_dir, s['name']))
+
+    if os.path.exists(base_snapshot_dir):
+        fs_subvolume_delete(base_snapshot_dir)
+
+    fs_subvolume_delete(os.path.join(pool, fs_path, name))
+
+
+def fs_pools(req):
+    results = []
+
+    for pool in pools:
+        total, free = fs_space_values(pool)
+        results.append(dict(name=pool, size=total, free_size=free, type='fs'))
+
+    return results
+
+
+def _invoke_retries(command, throw_exception):
+    # TODO take out this loop, used to handle bug in btrfs
+    # ERROR: Failed to lookup path for root 0 - No such file or directory
+
+    for i in range(0, 5):
+        result, out, err = invoke(command, False)
+        if result == 0:
+            return result, out, err
+        elif result == 19:
+            time.sleep(1)
+            continue
+        else:
+            raise TargetdError(TargetdError.UNEXPECTED_EXIT_CODE,
+                               "Unexpected exit code %d (Btrfs)" % result)
+
+    raise TargetdError(TargetdError.UNEXPECTED_EXIT_CODE,
+                       "Unable to execute command after "
+                       "multiple retries %s (Btrfs)" % (str(command)))
+
+
+def fs_hash():
+    fs_list = {}
+
+    for pool in pools:
+        full_path = os.path.join(pool, fs_path)
+
+        result, out, err = _invoke_retries(
+            [fs_cmd, 'subvolume', 'list', '-ua', pool], False)
+
+        data = split_stdout(out)
+        if len(data):
+            (total, free) = fs_space_values(full_path)
+            for e in data:
+                sub_vol = e[10]
+
+                prefix = fs_path + os.path.sep
+
+                if sub_vol[:len(prefix)] == prefix:
+                    key = os.path.join(pool, sub_vol)
+                    fs_list[key] = dict(
+                        name=sub_vol[len(prefix):],
+                        uuid=e[8],
+                        total_space=total,
+                        free_space=free,
+                        pool=pool,
+                        full_path=key
+                    )
+
+    return fs_list
+
+
+def ss(req, pool, name):
+    '''
+        Returns the snapshots belonging to this filesystem
+    :param req:
+    :param pool: pool of the filesystem
+    :param name: name of the subvol of this filesystem
+    :return: list of snapshots
+    '''
+    snapshots = []
+
+    full_path = os.path.join(pool, ss_path, name)
+
+    if os.path.exists(full_path):
+        result, out, err = _invoke_retries(
+            [fs_cmd, 'subvolume', 'list', '-s', full_path], False)
+
+        data = split_stdout(out)
+        if len(data):
+            for e in data:
+                ts = "%s %s" % (e[10], e[11])
+                time_epoch = int(
+                    time.mktime(time.strptime(ts, '%Y-%m-%d %H:%M:%S')))
+                st = dict(name=e[-1], uuid=e[-3], timestamp=time_epoch)
+                snapshots.append(st)
+
+    return snapshots
+
+
+def fs_clone(req, pool, name, dest_fs_name, snapshot_name=None):
+    if snapshot_name is not None:
+        source = os.path.join(pool, ss_path, name,
+                              snapshot_name)
+        dest = os.path.join(pool, fs_path, dest_fs_name)
+    else:
+        source = os.path.join(pool, fs_path, name)
+        dest = os.path.join(pool, fs_path, dest_fs_name)
+
+    if os.path.exists(dest):
+        raise TargetdError(TargetdError.EXISTS_CLONE_NAME,
+                           "Filesystem with that name exists (Btrfs)")
+
+    invoke([fs_cmd, 'subvolume', 'snapshot', source, dest])

--- a/targetd/backends/zfs.py
+++ b/targetd/backends/zfs.py
@@ -23,6 +23,7 @@ from time import time
 from targetd.main import TargetdError
 
 pools = []
+fs_pools = []
 zfs_cmd = ""
 zfs_enable_copy = False
 ALLOWED_DATASET_NAMES = re.compile('^[A-Za-z0-9][A-Za-z0-9_.\-]*$')
@@ -57,6 +58,13 @@ def has_pool(pool_name):
     """
     return pool_name in pools
 
+
+def has_fs_pool(pool_name):
+    """
+        This can be used to check if module owns given fs_pool without raising
+        exception
+    """
+    return pool_name in fs_pools
 
 def has_udev_path(udev_path):
     try:
@@ -114,9 +122,17 @@ def get_dev_path(pool_name, vol_name):
 def initialize(config_dict, init_pools):
     global pools
     global zfs_enable_copy
-    zfs_enable_copy = config_dict['zfs_enable_copy']
+    zfs_enable_copy = zfs_enable_copy or config_dict['zfs_enable_copy']
     check_pools_access(init_pools)
     pools = init_pools
+
+
+def fs_initialize(config_dict, init_pools):
+    global fs_pools
+    global zfs_enable_copy
+    zfs_enable_copy = zfs_enable_copy or config_dict['zfs_enable_copy']
+    check_pools_access(init_pools)
+    fs_pools = init_pools
 
 
 def _check_dataset_name(name):

--- a/targetd/fs.py
+++ b/targetd/fs.py
@@ -52,7 +52,7 @@ pools = {
     "btrfs": []
 }
 pool_modules = {
-    # disable for now:  "zfs": zfs,
+    "zfs": zfs,
     "btrfs": btrfs
 }
 
@@ -80,7 +80,9 @@ def initialize(config_dict):
         if info[Mount.MOUNT_POINT] in all_fs_pools:
             filesystem = info[Mount.FS_TYPE]
             if filesystem in pool_modules:
-                pools[filesystem].append(info[Mount.MOUNT_POINT])
+                # forward both mountpoint and device to the backend as ZFS prefers its own devices (pool/volume) and
+                # btrfs prefers mount points (/mnt/btrfs). Otherwise ZFS or btrfs needs to ask mounted_filesystems again
+                pools[filesystem].append({"mount": info[Mount.MOUNT_POINT], "device": info[Mount.DEVICE]})
             else:
                 raise TargetdError(TargetdError.NO_SUPPORT,
                                    'Unsupported filesystem {0} for pool {1}'.format(info[2], info[1]))

--- a/targetd/fs.py
+++ b/targetd/fs.py
@@ -76,6 +76,11 @@ def initialize(config_dict):
 
     all_fs_pools = list(config_dict['fs_pools'])
 
+    for mount in all_fs_pools:
+        if not os.path.exists(mount):
+            raise TargetdError(TargetdError.NOT_FOUND_FS,
+                               'The fs_pool {0} does not exist'.format(mount))
+
     for info in Mount.mounted_filesystems():
         if info[Mount.MOUNT_POINT] in all_fs_pools:
             filesystem = info[Mount.FS_TYPE]

--- a/targetd/fs.py
+++ b/targetd/fs.py
@@ -43,10 +43,6 @@ from targetd.backends import btrfs, zfs
 
 import logging as log
 
-fs_path = "targetd_fs"
-ss_path = "targetd_ss"
-fs_cmd = 'btrfs'
-
 pools = {
     "zfs": [],
     "btrfs": []

--- a/targetd/mount.py
+++ b/targetd/mount.py
@@ -1,0 +1,19 @@
+class Mount(object):
+    """
+    Abstraction around /proc/mounts
+    """
+    DEVICE = 0
+    MOUNT_POINT = 1
+    FS_TYPE = 2
+    OPTIONS = 3
+
+    @staticmethod
+    def mounted_filesystems():
+        """
+            Get all currently mounted filesystems from /proc/mounts
+            :return: generator of mount info arrays: the constants can be utilized
+            to get specific field information
+        """
+        with open('/proc/mounts', 'r') as proc_mount:
+            for mounted_fs in proc_mount.readlines():
+                yield mounted_fs.split(' ')

--- a/test/targetd.yaml
+++ b/test/targetd.yaml
@@ -2,6 +2,6 @@ user: "admin"
 target_name: iqn.2003-01.org.example.mach1:1234
 log_level: debug
 block_pools: [vg-targetd/thin_pool]
-zfs_block_pools: [zfs_targetd]
+zfs_block_pools: [zfs_targetd/block_pool]
 zfs_enable_copy: true
-fs_pools: [/mnt/btrfs]
+fs_pools: [/mnt/btrfs,/zfs_targetd/fs_pool]

--- a/test/test.sh
+++ b/test/test.sh
@@ -30,6 +30,8 @@ mount $loop2 /mnt/btrfs || exit 1
 
 # Create needed zfs
 zpool create zfs_targetd $loop3 || exit 1
+zfs create zfs_targetd/block_pool || exit 1
+zfs create zfs_targetd/fs_pool || exit 1
 
 export PYTHONPATH=$(pwd)
 python3 scripts/targetd > /tmp/targetd.log 2>&1 &
@@ -39,7 +41,13 @@ echo "Dumping targetd output ..."
 cat /tmp/targetd.log
 
 # get/buid/run libstoragemgmt tests
-./test/lsm_test.sh || exit 1
+./test/lsm_test.sh
+rc=$?
+if [ $rc -ne 0 ]; then
+  echo "Dumping targetd output on libstoragemgmt error ..."
+  cat /tmp/targetd.log
+  exit $rc
+fi
 
 # Run the actual tests, these need work ...
 echo "Running client test ..."


### PR DESCRIPTION
Adds ZFS support to the filesystem pools.

- Includes /proc/mounts parsing to determine which pools are supported
- Extracts btrfs into its own driver package
- Reduces the fs package to just the API and common helpers for said API
- Adds ZFS backend implementing the fs API
- Extends the test config with a ZFS fs pool

These changes allow ZFS as a backend for both iSCSI targets as well as NFS targets as discussed in #54.

Closes: #54 