### PR TITLE
Unit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *.pyc
+.coverage
+htmlcov
+*.pem
+test/*.pem

--- a/client
+++ b/client
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # based on code from git://github.com/openstack/nova.git
 # nova/volume/nexenta/jsonrpc.py
@@ -34,6 +34,8 @@ import json
 import time
 import socket
 import base64
+import ssl
+from test import testlib
 
 try:
     from urllib.request import (Request, urlopen)
@@ -46,13 +48,17 @@ host = 'localhost'
 port = 18700
 path = '/targetrpc'
 id_num = 1
-ssl = False
+use_ssl = True
 pools = ['vg-targetd/thin_pool','zfs_targetd/block_pool']
 fs_pools = ['/mnt/btrfs','/zfs_targetd/fs_pool']
+
+
+ctx = ssl.create_default_context(cafile=testlib.cert_file)
 
 def jsonrequest(method, params=None):
     print("%s %s" % ("+" * 20, method))
     global id_num
+    global use_ssl
     data = json.dumps(
         dict(id=id_num, method=method, params=params, jsonrpc="2.0"))
     id_num += 1
@@ -63,19 +69,23 @@ def jsonrequest(method, params=None):
         'Authorization': 'Basic %s' % (auth, )
     }
     #print('Sending JSON data: %s' % data)
-    if ssl:
+    if use_ssl:
         scheme = 'https'
     else:
         scheme = 'http'
     url = "%s://%s:%s%s" % (scheme, host, port, path)
     try:
         request = Request(url, data.encode('utf-8'), headers)
-        response_obj = urlopen(request)
+        if use_ssl:
+            response_obj = urlopen(request, context=ctx)
+        else:
+            response_obj = urlopen(request)
     except socket.error as e:
         print("error, retrying with SSL")
         url = "https://%s:%s%s" % (host, port, path)
         request = Request(url, data, headers)
-        response_obj = urlopen(request)
+        response_obj = urlopen(request, context=ctx)
+        use_ssl = True
     response_data = response_obj.read().decode('utf-8')
     #print('Got response: %s' % response_data)
     response = json.loads(response_data)

--- a/targetd/backends/btrfs.py
+++ b/targetd/backends/btrfs.py
@@ -96,17 +96,6 @@ def fs_space_values(mount_point):
     return total, free
 
 
-def pool_check(pool_name):
-    """
-    pool_name *cannot* be trusted, funcs taking a pool param must call
-    this or to ensure passed-in pool name is one targetd has
-    been configured to use.
-    """
-    if pool_name not in pools:
-        raise TargetdError(TargetdError.INVALID_POOL,
-                           "Invalid filesystem pool (Btrfs)")
-
-
 def has_fs_pool(pool_name):
     """
         This can be used to check if module owns given fs_pool without raising
@@ -116,8 +105,6 @@ def has_fs_pool(pool_name):
 
 
 def fs_create(req, pool_name, name, size_bytes):
-    pool_check(pool_name)
-
     full_path = os.path.join(pool_name, fs_path, name)
 
     if not os.path.exists(full_path):

--- a/targetd/backends/btrfs.py
+++ b/targetd/backends/btrfs.py
@@ -16,8 +16,10 @@
 #
 # fs support using btrfs.
 
+import logging as log
 import os
 import time
+
 from targetd.utils import invoke, TargetdError
 
 # Notes:
@@ -36,8 +38,6 @@ from targetd.utils import invoke, TargetdError
 # <mount>/targetd_ss/<fsname>/<snapshot name>
 #
 # There may be better ways of utilizing btrfs.
-
-import logging as log
 
 fs_path = "targetd_fs"
 ss_path = "targetd_ss"

--- a/targetd/backends/lvm.py
+++ b/targetd/backends/lvm.py
@@ -51,16 +51,6 @@ def get_vg_lv(pool_name):
         return pool_name, None
 
 
-def pool_check(pool_name):
-    """
-        pool_name *cannot* be trusted, funcs taking a pool param must call
-        this or vgopen() to ensure passed-in pool name is one targetd has
-        been configured to use.
-    """
-    if not has_pool(pool_name):
-        raise TargetdError(TargetdError.INVALID_POOL, "Invalid pool (LVM)")
-
-
 def has_pool(pool_name):
     """
         This can be used to check if module owns given pool without raising

--- a/targetd/backends/zfs.py
+++ b/targetd/backends/zfs.py
@@ -306,6 +306,11 @@ def create(req, pool, name, size):
 def fs_create(req, pool, name, size):
     _check_dataset_name(name)
     zfs_pool = pools_fs[pool]
+
+    if fs_info(zfs_pool, name) is not None:
+        raise TargetdError(TargetdError.EXISTS_FS_NAME,
+                           "FS already exists with that name (ZFS)")
+
     code, out, err = _zfs_exec_command(["create", zfs_pool + "/" + name])
     if code != 0:
         logging.error("Could not create volume %s on pool %s. Code: %s, stderr %s"
@@ -423,6 +428,10 @@ def fs_snapshot_delete(req, pool, name, ss_name):
 
 def fs_clone(req, pool, name, dest_fs_name, snapshot_name=None):
     zfs_pool = pools_fs[pool]
+
+    if fs_info(zfs_pool, dest_fs_name) is not None:
+        raise TargetdError(TargetdError.EXISTS_CLONE_NAME,
+                           "FS already exists with that name (ZFS)")
 
     _copy(req, zfs_pool, name, dest_fs_name, fs_info, snapshot_name)
 

--- a/targetd/backends/zfs.py
+++ b/targetd/backends/zfs.py
@@ -17,8 +17,8 @@
 import distutils.spawn
 import logging
 import re
-import subprocess, os
-from time import time, mktime, strptime
+import subprocess
+from time import time
 
 from targetd.main import TargetdError
 

--- a/targetd/backends/zfs.py
+++ b/targetd/backends/zfs.py
@@ -348,9 +348,7 @@ def _copy(req, pool, vol_orig, vol_new, info_fn, snap=None):
         raise TargetdError(TargetdError.NO_SUPPORT, "Copy on ZFS disabled. Consult manual before enabling it.")
     _check_dataset_name(vol_orig)
     _check_dataset_name(vol_new)
-    if info_fn(pool, vol_orig) is None:
-        raise TargetdError(TargetdError.INVALID_ARGUMENT,
-                           "Source volume %s does not exist on pool %s" % (vol_orig, pool))
+
     if info_fn(pool, vol_new) is not None:
         raise TargetdError(TargetdError.NAME_CONFLICT,
                            "Destination volume %s already exists on pool %s" % (vol_new, pool))

--- a/targetd/backends/zfs.py
+++ b/targetd/backends/zfs.py
@@ -396,7 +396,7 @@ def fs_snapshot(req, pool, name, dest_ss_name):
 
     info = snap_info(zfs_pool, name, dest_ss_name)
     if info is not None:
-        raise TargetdError(TargetdError.NAME_CONFLICT,
+        raise TargetdError(TargetdError.EXISTS_FS_NAME,
                            "Snapshot {0} already exists on pool {1} for {2}".format(dest_ss_name, pool, name))
 
     code, out, err = _zfs_exec_command(["snapshot", "{0}/{1}@{2}".format(zfs_pool, name, dest_ss_name)])

--- a/targetd/backends/zfs.py
+++ b/targetd/backends/zfs.py
@@ -28,6 +28,7 @@ zfs_cmd = ""
 zfs_enable_copy = False
 ALLOWED_DATASET_NAMES = re.compile('^[A-Za-z0-9][A-Za-z0-9_.\-]*$')
 
+
 class VolInfo(object):
     """
         Just to have attributes compatible with LVM info.
@@ -38,16 +39,6 @@ class VolInfo(object):
     def __init__(self, uuid, size):
         self.uuid = uuid
         self.size = size
-
-
-def pool_check(pool_name):
-    """
-        pool_name *cannot* be trusted, funcs taking a pool param must call
-        this to ensure passed-in pool name is one targetd has
-        been configured to use.
-    """
-    if not has_pool(pool_name):
-        raise TargetdError(TargetdError.INVALID_POOL, "Invalid pool (ZFS)")
 
 
 def has_pool(pool_name):

--- a/targetd/block.py
+++ b/targetd/block.py
@@ -120,11 +120,18 @@ def volumes(req, pool):
     return pool_module(pool).volumes(req, pool)
 
 
+def check_vol_exists(req, pool, name):
+    mod = pool_module(pool)
+    if any(v['name'] == name for v in mod.volumes(req, pool)):
+        return True
+    return False
+
+
 def create(req, pool, name, size):
     mod = pool_module(pool)
     # Check to ensure that we don't have a volume with this name already,
     # lvm/zfs will fail if we try to create a LV/dataset with a duplicate name
-    if any(v['name'] == name for v in mod.volumes(req, pool)):
+    if check_vol_exists(req, pool, name):
         raise TargetdError(TargetdError.NAME_CONFLICT,
                            "Volume with that name exists")
     mod.create(req, pool, name, size)
@@ -135,6 +142,11 @@ def get_so_name(pool, volname):
 
 
 def destroy(req, pool, name):
+    mod = pool_module(pool)
+    if not check_vol_exists(req, pool, name):
+        raise TargetdError(TargetdError.NOT_FOUND_VOLUME,
+                           "Volume %s not found in pool %s" % (name, pool))
+
     with ignored(RTSLibNotInCFS):
         fm = FabricModule('iscsi')
         t = Target(fm, target_name, mode='lookup')
@@ -151,6 +163,10 @@ def destroy(req, pool, name):
 
 
 def copy(req, pool, vol_orig, vol_new, timeout=10):
+    mod = pool_module(pool)
+    if not check_vol_exists(req, pool, vol_orig):
+        raise TargetdError(TargetdError.NOT_FOUND_VOLUME,
+                           "Volume %s not found in pool %s" % (vol_orig, pool))
     pool_module(pool).copy(req, pool, vol_orig, vol_new, timeout)
 
 

--- a/targetd/block.py
+++ b/targetd/block.py
@@ -19,9 +19,9 @@ from rtslib_fb import (Target, TPG, NodeACL, FabricModule, BlockStorageObject,
                        RTSRoot, NetworkPortal, LUN, MappedLUN, RTSLibError,
                        RTSLibNotInCFS, NodeACLGroup)
 
+from targetd.backends import lvm, zfs
 from targetd.main import TargetdError
 from targetd.utils import ignored, name_check
-from targetd.backends import lvm, zfs
 
 # Handle changes in rtslib_fb for the constant expressing maximum LUN number
 # https://github.com/open-iscsi/rtslib-fb/commit/20a50d9967464add8d33f723f6849a197dbe0c52

--- a/targetd/block.py
+++ b/targetd/block.py
@@ -174,7 +174,7 @@ def export_list(req):
                     initiator_wwn=na.node_wwn,
                     lun=mlun.mapped_lun,
                     vol_name=mlun_name,
-                    pool=mlun_pool,
+                    pool=mod.dev2pool_name(mlun_pool),
                     vol_uuid=vinfo.uuid,
                     vol_size=vinfo.size))
     return exports

--- a/targetd/fs.py
+++ b/targetd/fs.py
@@ -126,26 +126,21 @@ def fs_snapshot(req, fs_uuid, dest_ss_name):
     :return:
     """
     fs_ht = _get_fs_by_uuid(req, fs_uuid)
-
-    if fs_ht:
-        pool_module(fs_ht['pool']).fs_snapshot(req, fs_ht['pool'], fs_ht['name'], dest_ss_name)
+    pool_module(fs_ht['pool']).fs_snapshot(req, fs_ht['pool'], fs_ht['name'], dest_ss_name)
 
 
 def fs_snapshot_delete(req, fs_uuid, ss_uuid):
     fs_ht = _get_fs_by_uuid(req, fs_uuid)
     snapshot = _get_ss_by_uuid(req, fs_uuid, ss_uuid, fs_ht)
-    if fs_ht and snapshot:
-        pool_module(fs_ht['pool']).fs_snapshot_delete(req, fs_ht['pool'], fs_ht['name'], snapshot['name'])
+    pool_module(fs_ht['pool']).fs_snapshot_delete(req, fs_ht['pool'], fs_ht['name'], snapshot['name'])
 
 
 def fs_destroy(req, uuid):
     # Check to see if this file system has any read-only snapshots, if yes then
     # delete.  The API requires a FS to list its RO copies, we may want to
     # reconsider this decision.
-
     fs_ht = _get_fs_by_uuid(req, uuid)
-    if fs_ht:
-        pool_module(fs_ht['pool']).fs_destroy(req, fs_ht['pool'], fs_ht['name'])
+    pool_module(fs_ht['pool']).fs_destroy(req, fs_ht['pool'], fs_ht['name'])
 
 
 def fs_pools(req):
@@ -181,6 +176,7 @@ def _get_fs_by_uuid(req, fs_uuid):
     for f in fs(req):
         if f['uuid'] == fs_uuid:
             return f
+    raise TargetdError(TargetdError.NOT_FOUND_FS, "fs_uuid not found")
 
 
 def _get_ss_by_uuid(req, fs_uuid, ss_uuid, fs_ht=None):
@@ -190,19 +186,13 @@ def _get_ss_by_uuid(req, fs_uuid, ss_uuid, fs_ht=None):
     for s in ss(req, fs_uuid, fs_ht):
         if s['uuid'] == ss_uuid:
             return s
+    raise TargetdError(TargetdError.NOT_FOUND_SS, "snapshot not found")
 
 
 def fs_clone(req, fs_uuid, dest_fs_name, snapshot_id):
     fs_ht = _get_fs_by_uuid(req, fs_uuid)
-
-    if not fs_ht:
-        raise TargetdError(TargetdError.NOT_FOUND_FS, "fs_uuid not found")
-
     if snapshot_id:
         snapshot = _get_ss_by_uuid(req, fs_uuid, snapshot_id)
-        if not snapshot:
-            raise TargetdError(TargetdError.NOT_FOUND_SS, "snapshot not found")
-
         source = snapshot['name']
     else:
         source = None

--- a/targetd/fs.py
+++ b/targetd/fs.py
@@ -17,12 +17,11 @@
 # fs support using btrfs.
 
 import os
-import time
 
+from targetd.backends import btrfs, zfs
 from targetd.mount import Mount
 from targetd.nfs import Nfs, Export
-from targetd.utils import invoke, TargetdError
-from targetd.backends import btrfs, zfs
+from targetd.utils import TargetdError
 
 # Notes:
 #
@@ -40,8 +39,6 @@ from targetd.backends import btrfs, zfs
 # <mount>/targetd_ss/<fsname>/<snapshot name>
 #
 # There may be better ways of utilizing btrfs.
-
-import logging as log
 
 pools = {
     "zfs": [],

--- a/targetd/main.py
+++ b/targetd/main.py
@@ -17,10 +17,12 @@
 # sharable resources on the local machine, such as the LIO
 # kernel target.
 
-import os
-import setproctitle
-import signal
 import json
+import os
+import signal
+
+import setproctitle
+
 try:
     from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 except ImportError:

--- a/targetd/main.py
+++ b/targetd/main.py
@@ -152,9 +152,8 @@ class HTTPService(HTTPServer, object):
     """
     Handle requests one at a time
 
-    Note: The liblvm library we use is not thread safe, thus we need to
-    serialize access to it.  It has locking for concurrent process usage, but
-    we will keep things simple by serializing calls to it.
+    Note: Many things we are calling into are not thread safe and/or cannot be
+    done concurrently.  We will process things one at a time.
     """
 
 

--- a/targetd/nfs.py
+++ b/targetd/nfs.py
@@ -11,10 +11,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import re
 import os
 import os.path
+import re
 import shlex
+
 from targetd.utils import invoke
 
 

--- a/targetd/utils.py
+++ b/targetd/utils.py
@@ -15,9 +15,9 @@
 #
 # Utility functions.
 
-from subprocess import Popen, PIPE
-from contextlib import contextmanager
 import re
+from contextlib import contextmanager
+from subprocess import Popen, PIPE
 
 
 @contextmanager

--- a/targetd/utils.py
+++ b/targetd/utils.py
@@ -47,6 +47,7 @@ class TargetdError(Exception):
 
     # Specific to block
     EXISTS_INITIATOR = -52
+    NOT_FOUND_VOLUME = -103
     NOT_FOUND_VOLUME_GROUP = -152
     NOT_FOUND_ACCESS_GROUP = -200
     VOLUME_MASKED = -303

--- a/test/lsm_test.sh
+++ b/test/lsm_test.sh
@@ -3,6 +3,8 @@
 # Not finding libStorageMgmt packages, so let download and build.  We should
 # try and fix that.
 
+TEST_DIR=$1
+
 cd /tmp || exit 1
 
 git clone http://github.com/libstorage/libstoragemgmt || exit 1
@@ -41,7 +43,7 @@ LSMDLOG=/tmp/lsmd.log
 PYTHONPATH=$PYENV daemon/lsmd -v -d --plugindir `pwd`/plugin > $LSMDLOG 2>&1 &
 
 # Run the client test
-PYTHONPATH=$PYENV test/plugin_test.py -v --uri targetd://admin@localhost --password targetd
+PYTHONPATH=$PYENV test/plugin_test.py -v --uri targetd+ssl://admin@localhost?ca_cert_file=$TEST_DIR/targetd_cert.pem --password targetd
 
 rc=$?
 if [ $rc -ne 0 ]; then

--- a/test/make_test_cert.sh
+++ b/test/make_test_cert.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Make a source of random for openssl
+dd if=/dev/random of=~/.rnd bs=1024 count=1 || exit 1
+
+# Generate the private key
+openssl genrsa -out targetd_key.pem 2048 || exit 1
+
+# Make the public cert. for testing
+openssl req -new -x509 -key targetd_key.pem -out targetd_cert.pem -days 30 -subj "/C=US/ST=private/L=province/O=city/CN=localhost" -addext "subjectAltName = DNS:localhost"
+
+# Copy them
+cp targetd_key.pem targetd_cert.pem /etc/target/. || exit 1
+
+# Test code expecting cert in same directory as test lib.
+cp targetd_cert.pem test/. || exit 1
+chmod 400 /etc/target/*.pem || exit 1
+
+exit 0

--- a/test/targetd.yaml
+++ b/test/targetd.yaml
@@ -5,3 +5,4 @@ block_pools: [vg-targetd/thin_pool]
 zfs_block_pools: [zfs_targetd/block_pool]
 zfs_enable_copy: true
 fs_pools: [/mnt/btrfs,/zfs_targetd/fs_pool]
+ssl: true

--- a/test/targetd_test.py
+++ b/test/targetd_test.py
@@ -359,12 +359,6 @@ class TestTargetd(unittest.TestCase):
             # Create a volume, copy it, destroy the copy, destroy original
             vol = TestTargetd._vol_create(block_pool, vol_name)
             vol_copy = TestTargetd._vol_copy(block_pool, vol, vol_copy_name)
-
-            # It appears we run into a race condition on zfs with the error
-            # "dataset is busy", lets sleep a bit to make this hopefully go
-            # away.  More here: https://github.com/openzfs/zfs/issues/1810
-            time.sleep(10)
-
             self._vol_destroy(block_pool, vol_copy)
             self._vol_destroy(block_pool, vol)
 

--- a/test/targetd_test.py
+++ b/test/targetd_test.py
@@ -1,0 +1,684 @@
+#!/usr/bin/python3
+
+import unittest
+import json
+import random
+import time
+import string
+from targetd.utils import TargetdError
+from os import getenv
+from requests.exceptions import ConnectionError
+from test import testlib
+
+
+def jsonrequest(method, params=None, data=None):
+    return testlib.rpc(method, params, data)
+
+
+def _rs(length):
+    return ''.join(random.choice(string.ascii_lowercase) for _ in range(length))
+
+
+def r_iqn():
+    return 'iqn.1994-05.com.domain:01.' + _rs(6)
+
+
+def rs(prefix="td", length=4):
+    """
+    Generate a random string with optional prefix
+    """
+    rp = _rs(length)
+
+    if prefix is not None:
+        return '%s_%s' % (prefix, rp)
+    return rp
+
+
+class TargetdObj(object):
+
+    @staticmethod
+    def build(objhash):
+        o = TargetdObj()
+        o.rpc = objhash
+        return o
+
+    def __getattr__(self, k):
+        if k in self.rpc:
+            if k in ['size', 'free_size']:
+                return int(self.rpc[k])
+            return self.rpc[k]
+        # Not present for FS pools
+        if k == "uuid":
+            return None
+        else:
+            raise AttributeError(
+                "'TargetdObj' object %s has no attribute '%s'" %
+                (str(self), k))
+
+    def __str__(self):
+        s = ""
+        for k, v in self.rpc.items():
+            s += "%s: %s " % (k, v)
+        return s
+
+
+class TestConnect(unittest.TestCase):
+
+    def _test_ep_bad_auth(self, username=True):
+
+        existing_user = testlib.user
+        existing_pw = testlib.password
+
+        if username:
+            testlib.user = rs(length=10)
+        else:
+            testlib.password = rs(length=10)
+
+        error_code = 0
+        try:
+            jsonrequest("pool_list")
+        except TargetdError as e:
+            error_code = e.error
+        finally:
+            testlib.user = existing_user
+            testlib.password = existing_pw
+
+        self.assertEqual(error_code, 401, "testing bad auth.")
+
+    def test_ep_bad_auth(self):
+        self._test_ep_bad_auth()
+        self._test_ep_bad_auth(False)
+
+    def test_ep_bad_path(self):
+
+        existing = testlib.rpc_path
+        bad_path = "/" + _rs(10)
+        testlib.rpc_path = bad_path
+
+        error_code = 0
+        try:
+            jsonrequest("pool_list")
+        except TargetdError as e:
+            error_code = e.error
+        finally:
+            testlib.rpc_path = existing
+
+        self.assertEqual(error_code, 404, "testing bad path %s" % bad_path)
+
+    def test_ep_method_not_found(self):
+        error_code = 0
+        try:
+            jsonrequest("pool_listing")
+        except TargetdError as e:
+            error_code = e.error
+
+        self.assertEqual(error_code, -32601, "testing method")
+
+    def test_ep_invalid_arg(self):
+        error_code = 0
+        try:
+            jsonrequest("pool_list", dict(foo="bar"))
+        except TargetdError as e:
+            error_code = e.error
+
+        self.assertEqual(error_code, TargetdError.INVALID_ARGUMENT)
+
+    def test_ep_invalid_json_version(self):
+        method = "pool_list"
+        params = None
+
+        data = json.dumps(
+            dict(id=100,
+                 method=method,
+                 params=params, jsonrpc="not_a_version")).encode('utf-8')
+
+        error_code = 0
+        try:
+            jsonrequest(method, params=None, data=data)
+        except TargetdError as e:
+            error_code = e.error
+
+        self.assertEqual(error_code, -32600)
+
+    def test_ep_invalid_json(self):
+        method = "pool_list"
+        params = None
+
+        data = json.dumps(
+            dict(id=100,
+                 method=method,
+                 params=params, jsonrpc="2.0")).encode('utf-8')
+
+        self.assertRaises(ConnectionError,
+                          jsonrequest,
+                          method, params=None, data=data[0:len(data)-10])
+
+    def test_gp_simple(self):
+        # Basic good path
+        jsonrequest("pool_list")
+
+
+class TestTargetd(unittest.TestCase):
+
+    @staticmethod
+    def _pools():
+        return [TargetdObj.build(x) for x in jsonrequest("pool_list")]
+
+    @staticmethod
+    def _block_pools():
+        return [TargetdObj.build(x)
+                for x in jsonrequest("pool_list")
+                if x['type'] == 'block']
+
+    @staticmethod
+    def _vol_create(pool, name, size=1024 * 1024 * 100):
+        jsonrequest("vol_create", dict(pool=pool.name, name=name, size=size))
+        # just created, get it and return
+        return TestTargetd._vol_list(pool, name)[0]
+
+    def _vol_destroy(self, pool, vol):
+        jsonrequest("vol_destroy", dict(pool=pool.name, name=vol.name))
+        missing_volume = TestTargetd._vol_list(pool, vol.name)
+        self.assertEqual(len(missing_volume), 0,
+                         "Expected destroyed volume to not be in vol_list")
+
+    @staticmethod
+    def _vol_copy(pool, vol_orig, vol_new_name):
+        jsonrequest("vol_copy",
+                    dict(
+                        pool=pool.name,
+                        vol_orig=vol_orig.name,
+                        vol_new=vol_new_name))
+        return TestTargetd._vol_list(pool, vol_new_name)[0]
+
+    @staticmethod
+    def _fs_create(pool, name, size=1024 * 1024 * 100):
+        jsonrequest("fs_create",
+                    dict(pool_name=pool.name, name=name, size_bytes=size))
+        # just created, get it and return
+        return TestTargetd._fs_list(name)[0]
+
+    @staticmethod
+    def _fs_clone(fs, dest_fs_name, snapshot_id=""):
+        args = dict(fs_uuid=fs.uuid, dest_fs_name=dest_fs_name,
+                    snapshot_id=snapshot_id)
+        jsonrequest("fs_clone", args)
+        return TestTargetd._fs_list(dest_fs_name)[0]
+
+    def _fs_snapshot(self, fs, dest_ss_name, snapshot_id=""):
+        args = dict(fs_uuid=fs.uuid, dest_ss_name=dest_ss_name)
+
+        # Make sure time stamp makes sense and is reasonably close,
+        # we don't want false positives because clocks are slightly off if
+        # test and service are on different systems
+
+        delta = int(getenv("TARGETD_UT_CLOCK_DRIFT", 300))
+        start = time.time() - delta
+        jsonrequest("fs_snapshot", args)
+        end = time.time() + delta
+        search = TestTargetd._ss_list(fs, dest_ss_name)
+        self.assertEqual(len(search), 1,
+                         "expecting to find newly created snapshot %s" % fs)
+        found = search[0]
+        ts = int(found.timestamp)
+        self.assertTrue(
+            (start <= ts <= end),
+            "Snapshot timestamp is out of range? (%d .. %d .. %d)" %
+            (start, ts, end))
+        return found
+
+    def _fs_destroy(self, fs):
+        jsonrequest("fs_destroy", dict(uuid=fs.uuid))
+        fs_list = TestTargetd._fs_list()
+        matched = [x for x in fs_list if x.uuid == fs.uuid]
+        self.assertEqual(len(matched), 0,
+                         "Expected destroyed fs to not be in fs_list")
+
+    def _fs_snapshot_delete(self, fs, ss):
+        jsonrequest(
+            "fs_snapshot_delete", dict(fs_uuid=fs.uuid, ss_uuid=ss.uuid))
+
+        search = TestTargetd._ss_list(fs, ss.name)
+        self.assertEqual(len(search), 0,
+                         "Expected deleted ss to not be in ss_list %s" % ss)
+
+    @staticmethod
+    def _vol_list(pool, name=None):
+
+        vols = [TargetdObj.build(x)
+                    for x in jsonrequest("vol_list", dict(pool=pool.name))]
+
+        if name:
+            return [x for x in vols if x.name == name]
+        return vols
+
+    @staticmethod
+    def _fs_list(name=None):
+
+        fs = [TargetdObj.build(x)
+                for x in jsonrequest("fs_list", dict())]
+
+        if name:
+            return [x for x in fs if x.name == name]
+        return fs
+
+    @staticmethod
+    def _ss_list(fs, name=None):
+        ss = [TargetdObj.build(x)
+              for x in jsonrequest("ss_list", dict(fs_uuid=fs.uuid))]
+        if name:
+            return [x for x in ss if x.name == name]
+        return ss
+
+    @staticmethod
+    def _fs_pools():
+        return [TargetdObj.build(x)
+                for x in jsonrequest("pool_list")
+                if x['type'] == 'fs']
+
+    @staticmethod
+    def _initiator_list(standalone=False, wwid=None):
+        initiators = [TargetdObj.build(x)
+                        for x in jsonrequest(
+                            "initiator_list",
+                            dict(standalone_only=str(standalone)))]
+        if wwid:
+            return [x for x in initiators if x.init_id == wwid]
+        return initiators
+
+    @staticmethod
+    def _export_list(st=None):
+        """
+        Retrieve export list or constrain to single item.
+        :param st: search_tuple (pool_name, vol_name, initiator_wwn, lun)
+        :return: list of exports
+        """
+        exports = [TargetdObj.build(x)
+                    for x in jsonrequest("export_list")]
+
+        if st is None:
+            return exports
+        return [x for x in exports
+                 if (st[0] == x.pool and st[1] == x.vol_name and
+                        st[2] == x.initiator_wwn and st[3] == x.lun)]
+
+    def _export_create(self, pool, vol, initiator_wwn=None, lun=0):
+
+        if initiator_wwn is None:
+            initiator_wwn = r_iqn()
+
+        jsonrequest(
+            "export_create",
+            dict(
+                pool=pool.name, vol=vol.name, initiator_wwn=initiator_wwn,
+                lun=lun))
+
+        result = TestTargetd._export_list(
+            (pool.name, vol.name, initiator_wwn, lun))
+
+        self.assertEqual(len(result), 1,
+                         "Expected 1 found export that we just created!")
+
+        initiator = TestTargetd._initiator_list(wwid=initiator_wwn)
+        self.assertEqual(len(initiator), 1,
+                             "Expected 1 found for initiator list")
+
+        return result[0]
+
+    def _export_destroy(self, export):
+        jsonrequest("export_destroy",
+                    dict(pool=export.pool,
+                         vol=export.vol_name,
+                         initiator_wwn=export.initiator_wwn))
+
+        expect_not_found = TestTargetd._export_list(
+            (export.pool, export.vol_name, export.initiator_wwn, export.lun))
+        self.assertEqual(len(expect_not_found), 0, "expect export gone!")
+        initiator = TestTargetd._initiator_list(wwid=export.initiator_wwn)
+        self.assertEqual(len(initiator), 0,
+                         "Expected 1 found for initiator list")
+
+    def test_gp_pool_list(self):
+        p = TestTargetd._pools()
+
+        self.assertGreater(len(p), 0, "Expecting at least 1 pool!")
+        for i in p:
+            self.assertGreater(len(i.name), 0, "Name should not be empty")
+            self.assertGreater(i.size, 0, "Pool size should not be 0")
+            self.assertTrue(i.type == 'fs' or i.type == 'block')
+            self.assertTrue(i.free_size <= i.size)
+            if i.type == 'fs':
+                self.assertIsNone(i.uuid,
+                                  "file pool have no uuid %s" % i)
+
+    def test_gp_vol_create_copy_destroy_operations(self):
+        for block_pool in self._block_pools():
+            vol_name = rs(length=6)
+            vol_copy_name = vol_name + "_copy"
+
+            # Create a volume, copy it, destroy the copy, destroy original
+            vol = TestTargetd._vol_create(block_pool, vol_name)
+            vol_copy = TestTargetd._vol_copy(block_pool, vol, vol_copy_name)
+
+            # It appears we run into a race condition on zfs with the error
+            # "dataset is busy", lets sleep a bit to make this hopefully go
+            # away.  More here: https://github.com/openzfs/zfs/issues/1810
+            time.sleep(10)
+
+            self._vol_destroy(block_pool, vol_copy)
+            self._vol_destroy(block_pool, vol)
+
+    def test_ep_copy_missing_volume(self):
+        for block_pool in self._block_pools():
+            vol_name = rs(length=6)
+            vol_copy_name = vol_name + "_copy"
+
+            # Create a volume, copy it, destroy the copy, destroy original
+            vol = TestTargetd._vol_create(block_pool, vol_name)
+
+            # Change name
+            vol.name = vol.name + "_missing"
+
+            error_code = 0
+            try:
+                TestTargetd._vol_copy(block_pool, vol, vol_copy_name)
+            except TargetdError as e:
+                error_code = e.error
+            self.assertEqual(error_code, TargetdError.NOT_FOUND_VOLUME)
+
+            # Correct name for deletion
+            vol.name = vol_name
+            self._vol_destroy(block_pool, vol)
+
+    def test_gp_export_operations(self):
+        exports = TestTargetd._export_list()
+
+        for e in exports:
+            # Check search for specific is working
+            export = TestTargetd._export_list(
+                (e.pool, e.vol_name, e.initiator_wwn, e.lun))
+
+        if len(exports) == 0:
+            for block_pool in self._block_pools():
+                # Create a volume, then export it
+                vol = TestTargetd._vol_create(block_pool, rs(length=6))
+                export = self._export_create(block_pool, vol)
+                self._export_destroy(export)
+                self._vol_destroy(block_pool, vol)
+
+    def test_ep_vol_name_collision(self):
+        for block_pool in self._block_pools():
+            vol_name = "some_block_vol"
+            # Make sure we get the expected error for duplicate name during
+            # volume creation and volume copy
+            vol = TestTargetd._vol_create(block_pool, vol_name)
+
+            error_code = 1
+            try:
+                TestTargetd._vol_create(block_pool, vol_name)
+            except TargetdError as e:
+                error_code = e.error
+            self.assertTrue(error_code == TargetdError.NAME_CONFLICT,
+                            block_pool)
+
+            error_code = 1
+            try:
+                TestTargetd._vol_copy(block_pool, vol, vol_name)
+            except TargetdError as e:
+                error_code = e.error
+
+            self.assertTrue(error_code == TargetdError.NAME_CONFLICT,
+                            block_pool)
+
+            self._vol_destroy(block_pool, vol)
+
+    def test_ep_non_existent_vol_destroy(self):
+        vol = TargetdObj.build(dict(name='no_such_volume_'))
+        for block_pool in self._block_pools():
+            error_code = 1
+            try:
+                self._vol_destroy(block_pool, vol)
+            except TargetdError as e:
+                error_code = e.error
+            self.assertEqual(error_code,
+                             TargetdError.NOT_FOUND_VOLUME, block_pool)
+
+    def test_ep_non_existent_pool(self):
+        pool = TargetdObj.build(dict(name='no_such_pool_'))
+        vol = TargetdObj.build(dict(name='no_such_volume_'))
+        error_code = 1
+        try:
+            self._vol_destroy(pool, vol)
+        except TargetdError as e:
+            error_code = e.error
+
+        self.assertEqual(error_code, TargetdError.INVALID_POOL, pool)
+
+    def test_gp_fs_create_destroy(self):
+        for fs_pool in TestTargetd._fs_pools():
+            fs = TestTargetd._fs_create(fs_pool, rs(length=10))
+            self._fs_destroy(fs)
+
+    def test_ep_fs_destroy(self):
+        for fs_pool in TestTargetd._fs_pools():
+            fs = TargetdObj.build(dict(uuid="123"))
+            error_code = 0
+            try:
+                self._fs_destroy(fs)
+            except TargetdError as e:
+                error_code = e.error
+
+            self.assertEqual(error_code, TargetdError.NOT_FOUND_FS, fs_pool)
+
+    def test_ep_fs_dupe(self):
+        for fs_pool in TestTargetd._fs_pools():
+            name = rs(length=10)
+            fs = TestTargetd._fs_create(fs_pool, name)
+
+            error_code = 0
+            try:
+                dupe = self._fs_create(fs_pool, name)
+            except TargetdError as e:
+                error_code = e.error
+
+            self.assertEqual(error_code, TargetdError.EXISTS_FS_NAME, fs_pool)
+            self._fs_destroy(fs)
+
+    def test_gp_fs_clone(self):
+        for fs_pool in TestTargetd._fs_pools():
+            fs = TestTargetd._fs_create(fs_pool, rs(length=10))
+            clone = TestTargetd._fs_clone(fs, rs(length=10) + "_clone")
+            self._fs_destroy(clone)
+            self._fs_destroy(fs)
+
+    def test_ep_fs_dupe_clone_name(self):
+        for fs_pool in TestTargetd._fs_pools():
+            fs = TestTargetd._fs_create(fs_pool, rs(length=10))
+            name = rs(length=10) + "_clone"
+            clone = TestTargetd._fs_clone(fs, name)
+
+            error_code = 0
+            try:
+                self._fs_clone(fs, name)
+            except TargetdError as e:
+                error_code = e.error
+
+            self.assertEqual(error_code,
+                             TargetdError.EXISTS_CLONE_NAME,
+                             fs_pool)
+
+            self._fs_destroy(clone)
+            self._fs_destroy(fs)
+
+    def test_ep_fs_clone_bad_source(self):
+        for fs_pool in TestTargetd._fs_pools():
+            fs = TestTargetd._fs_create(fs_pool, rs(length=10))
+
+            uuid = fs.uuid
+            fs.uuid = rs(length=8)
+
+            error_code = 0
+            try:
+                self._fs_clone(fs, rs(length=8))
+            except TargetdError as e:
+                error_code = e.error
+            finally:
+                fs.uuid = uuid
+
+            self.assertEqual(error_code,
+                             TargetdError.NOT_FOUND_FS,
+                             fs_pool)
+            self._fs_destroy(fs)
+
+
+    def test_gp_fs_snapshot(self):
+        for fs_pool in TestTargetd._fs_pools():
+            fs = TestTargetd._fs_create(fs_pool, rs(length=10))
+            ss = self._fs_snapshot(fs, rs(length=10) + "_ss")
+            self._fs_snapshot_delete(fs, ss)
+            self._fs_destroy(fs)
+
+    def test_ep_fs_snapshot_not_exist(self):
+        for fs_pool in TestTargetd._fs_pools():
+            fs = TestTargetd._fs_create(fs_pool, rs(length=10))
+            ss = self._fs_snapshot(fs, rs(length=10) + "_ss")
+
+            error_code = 0
+            uuid = ss.uuid
+            ss.uuid = rs(length=5)
+            try:
+                self._fs_snapshot_delete(fs, ss)
+            except TargetdError as e:
+                error_code = e.error
+            finally:
+                ss.uuid = uuid
+
+            self.assertEqual(error_code, TargetdError.NOT_FOUND_SS)
+            self._fs_snapshot_delete(fs, ss)
+            self._fs_destroy(fs)
+
+    def test_ep_fs_snapshot_dupe_name(self):
+        for fs_pool in TestTargetd._fs_pools():
+            fs = TestTargetd._fs_create(fs_pool, rs(length=10))
+            ss_name = rs(length=10) + "_ss"
+            ss = self._fs_snapshot(fs, ss_name)
+
+            error_code = 0
+            try:
+                dupe = self._fs_snapshot(fs, ss_name)
+            except TargetdError as e:
+                error_code = e.error
+
+            self.assertEqual(error_code, TargetdError.EXISTS_FS_NAME)
+
+            self._fs_snapshot_delete(fs, ss)
+            self._fs_destroy(fs)
+
+    def test_ep_no_such_pool(self):
+        error_code = 0
+        try:
+            jsonrequest(
+                "vol_create",
+                dict(pool=rs(length=20), name="wont_create",
+                     size=1024*1024*100))
+        except TargetdError as e:
+            error_code = e.error
+
+        self.assertEqual(error_code, TargetdError.INVALID_POOL)
+
+    def test_ep_no_such_fs_pool(self):
+        error_code = 0
+        try:
+            jsonrequest(
+                "fs_create",
+                dict(pool_name=rs(length=10), name="whatever",
+                     size_bytes=1024*1024*100))
+        except TargetdError as e:
+            error_code = e.error
+
+        self.assertEqual(error_code, TargetdError.INVALID_POOL)
+
+    def test_ep_no_such_snapshot(self):
+        for fs_pool in TestTargetd._fs_pools():
+            fs = TestTargetd._fs_create(fs_pool, rs(length=10))
+            ss = self._fs_snapshot(fs, rs(length=10) + "_ss")
+
+            uuid = ss.uuid
+            ss.uuid = "NO_SUCH_UUID"
+
+            error_code = 0
+            try:
+                self._fs_snapshot_delete(fs, ss)
+            except TargetdError as e:
+                error_code = e.error
+
+            self.assertEqual(
+                error_code, TargetdError.NOT_FOUND_SS,
+                " fs_snapshot_delete expecting NOT_FOUND_SS when trying to"
+                " delete the snapshot with incorrect uuid")
+
+            ss.uuid = uuid
+            self._fs_snapshot_delete(fs, ss)
+            self._fs_destroy(fs)
+
+    def test_ep_fs_snapshot(self):
+        """
+        Create a snapshot from a FS and then try to delete the snapshot using
+        FS delete instead of SS delete expecting a NOT_FOUND_FS error
+        :return: None
+        """
+        for fs_pool in TestTargetd._fs_pools():
+            fs = TestTargetd._fs_create(fs_pool, rs(length=10))
+            ss = self._fs_snapshot(fs, rs(length=10) + "_ss")
+            # Try to use fs_destroy on a snapshot should fail
+            error_code = 0
+            try:
+                self._fs_destroy(ss)
+            except TargetdError as e:
+                error_code = e.error
+            self.assertEqual(
+                error_code, TargetdError.NOT_FOUND_FS,
+                "fs_destroy expecting NOT_FOUND_FS when trying to use ss"
+                " uuid, fs_pool = %s" % fs_pool.name)
+
+            self._fs_destroy(fs)
+
+    def test_gp_fs_clone_from_snapshot(self):
+        for fs_pool in TestTargetd._fs_pools():
+            fs = TestTargetd._fs_create(fs_pool, rs(length=10))
+            ss = self._fs_snapshot(fs, rs(length=10) + "_ss")
+            clone = TestTargetd._fs_clone(fs, rs(length=10) + "_clone", ss.uuid)
+            self._fs_destroy(clone)
+            self._fs_snapshot_delete(fs, ss)
+            self._fs_destroy(fs)
+
+    def tearDown(self):
+        for e in TestTargetd._export_list():
+            self._export_destroy(e)
+
+        # As we can have dependencies we will loop trying to delete each one
+        # until they are all gone
+        while True:
+            keep_going = False
+            for pool in TestTargetd._block_pools():
+                for vol in TestTargetd._vol_list(pool):
+                    try:
+                        self._vol_destroy(pool, vol)
+                    except TargetdError:
+                        keep_going = True
+            if not keep_going:
+                break
+
+        while True:
+            keep_going = False
+            for fs in TestTargetd._fs_list():
+                try:
+                    self._fs_destroy(fs)
+                except TargetdError:
+                    keep_going = True
+            if not keep_going:
+                break
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,62 +1,126 @@
 #!/bin/bash
 
-mkdir -p /etc/target || exit 1
-cp test/targetd.yaml /etc/target/ || exit 1
+clean_up ()
+{
+    # Try to clean everything up so we can re-run the test during
+    # development
+    pkill --signal SIGINT targetd || echo "Warning: Unable to end targetd process"
+    # Give targetd a moment to stop ...
+    sleep 1
+
+    pkill lsmd || echo "Warning: Unable to end lsmd process"
+
+    python3-coverage report || echo "Warning: Unable to generate report"
+
+    zpool destroy zfs_targetd || echo "Warning: unable to destroy zpool zfs_targetd"
+    umount /mnt/btrfs || echo "Warning: , unable to unmount /mnt/btrfs"
+    vgremove -f vg-targetd || echo "Warning: unable to remove VG vg-targetd"
+    losetup -D || echo "Warning: Unable to remove all loopback devices"
+    rm -f /tmp/block*.img || echo "Warning: error while removing sparse files"
+    rm -rf /tmp/libstoragemgmt || echo "Warning: Unable to remove /tmp/libstoragemgmt"
+
+    exit $1
+}
+
+# Handle a couple options to allow developers to be more productive in
+# their test environment.
+SETUP=0
+TEARDOWN=0
+if [ $# -eq 1 ]; then
+    if [ $1 = "setup" ]; then
+        SETUP=1
+    elif [ $1 = "teardown" ]; then
+        TEARDOWN=1
+    else
+        echo "test.sh [setup|teardown] or no args to run tests"
+        exit 1
+    fi
+fi
+
+# Used during development to clean up
+if [  $TEARDOWN -eq 1 ]; then
+    clean_up 0
+fi
+
+# Will use to see how well the test coverage is ...
+apt-get install python3-coverage
+
+mkdir -p /etc/target || clean_up 1
+cp test/targetd.yaml /etc/target/ || clean_up 1
 
 # Needed for NFS functionality
-mkdir -p /etc/exports.d || exit 1
+mkdir -p /etc/exports.d || clean_up 1
 
 # We don't place the password into the example yaml to prevent
 # people from using it and having it contain a bad password by default
 echo "password: targetd" >> /etc/target/targetd.yaml
 
+# We are going to utilize SSL for all tests as users should be using
+# it, so make a self signed cert for testing
+./test/make_test_cert.sh || clean_up 1
+
 # Create the needed block devices for lvm, btrfs, and zfs for testing
-truncate -s 1T /tmp/block1.img || exit 1
-truncate -s 1T /tmp/block2.img || exit 1
-truncate -s 1T /tmp/block3.img || exit 1
+truncate -s 1T /tmp/block1.img || clean_up 1
+truncate -s 1T /tmp/block2.img || clean_up 1
+truncate -s 1T /tmp/block3.img || clean_up 1
 
 loop1=$(losetup -f --show /tmp/block1.img)
 loop2=$(losetup -f --show /tmp/block2.img)
 loop3=$(losetup -f --show /tmp/block3.img)
 
 # Create lvm needed parts
-vgcreate vg-targetd $loop1 || exit 1
-lvcreate -L 500G -T vg-targetd/thin_pool || exit 1
+vgcreate vg-targetd $loop1 || clean_up 1
+lvcreate -L 500G -T vg-targetd/thin_pool || clean_up 1
 
 # Create btrfs
-mkfs.btrfs $loop2 || exit 1
-mkdir -p /mnt/btrfs || exit 1
-mount $loop2 /mnt/btrfs || exit 1
+mkfs.btrfs $loop2 || clean_up 1
+mkdir -p /mnt/btrfs || clean_up 1
+mount $loop2 /mnt/btrfs || clean_up 1
 
 # Create needed zfs
-zpool create zfs_targetd $loop3 || exit 1
-zfs create zfs_targetd/block_pool || exit 1
-zfs create zfs_targetd/fs_pool || exit 1
+zpool create zfs_targetd $loop3 || clean_up 1
+zfs create zfs_targetd/block_pool || clean_up 1
+zfs create zfs_targetd/fs_pool || clean_up 1
+
+if [ $SETUP -eq 1  ]; then
+    exit 0
+fi
 
 export PYTHONPATH=$(pwd)
-python3 scripts/targetd > /tmp/targetd.log 2>&1 &
+python3-coverage run scripts/targetd > /tmp/targetd.log 2>&1 &
 
-sleep 5 || exit 1
+sleep 5 || clean_up 1
 echo "Dumping targetd output ..."
 cat /tmp/targetd.log
 
-# get/buid/run libstoragemgmt tests
-./test/lsm_test.sh
+echo "Running unit test ..."
+test/targetd_test.py -v
+rc=$?
+if [ $rc -ne 0 ]; then
+    echo "Dumping targetd output on unit test error ..."
+    cat /tmp/targetd.log
+    clean_up $rc
+fi
+
+# get/build/run libstoragemgmt tests
+TEST_DIR="$(pwd)/test"
+./test/lsm_test.sh $TEST_DIR
 rc=$?
 if [ $rc -ne 0 ]; then
   echo "Dumping targetd output on libstoragemgmt error ..."
   cat /tmp/targetd.log
-  exit $rc
+  clean_up $rc
 fi
 
-# Run the actual tests, these need work ...
+# Run the actual legacy tests ...
 echo "Running client test ..."
 python3 client
 rc=$?
 if [ $rc -ne 0 ]; then
     echo "Dumping targetd output on client error ..."
     cat /tmp/targetd.log
-    exit $rc
+    clean_up
+    clean_up $rc
 fi
 
-exit 0
+clean_up 0

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -1,0 +1,66 @@
+
+import requests
+from requests.auth import HTTPBasicAuth
+
+from os import getenv, path
+import json
+from targetd.utils import TargetdError
+
+# based on code from git://github.com/openstack/nova.git
+# nova/volume/nexenta/jsonrpc.py which is under Apache License, Version 2.0
+# and copied from `../client` file in the targetd repo and modified for
+# unit test.  TODO: Convert client over to using this too.
+
+# Make most of these changeable
+user = getenv("TARGETD_UT_USER", "admin")
+password = getenv("TARGETD_UT_PASSWORD", "targetd")
+host = getenv("TARGETD_UT_HOST", "localhost")
+port = int(getenv("TARGETD_UT_PORT", 18700))
+rpc_path = '/targetrpc'
+cert_file = getenv("TARGETD_UT_CERTFILE",
+                   path.dirname(path.realpath(__file__)) +
+                   "/targetd_cert.pem")
+
+id_num = 1
+
+
+def _json_payload(payload):
+    assert payload.get('jsonrpc') == "2.0"
+    if 'error' in payload:
+        error_code = int(payload['error']['code'])
+        if error_code <= 0:
+            raise TargetdError(error_code,
+                               payload['error'].get('message', ''))
+        else:
+            raise Exception("Invalid error code %d, should be negative!" %
+                            error_code)
+    else:
+        return payload['result']
+
+
+def rpc(method, params=None, data=None):
+    global id_num
+    auth_info = HTTPBasicAuth(user, password)
+
+    if not data:
+        data = json.dumps(
+            dict(id=id_num,
+                 method=method,
+                 params=params, jsonrpc="2.0")).encode('utf-8')
+
+    id_num += 1
+    url = "%s://%s:%s%s" % ('https', host, port, rpc_path)
+    r = requests.post(url, data=data, auth=auth_info, verify=cert_file)
+    if r.status_code == 200:
+        # JSON RPC error
+        return _json_payload(r.json())
+    else:
+        # Transport error
+        raise TargetdError(r.status_code, str(r))
+
+
+if __name__ == "__main__":
+    try:
+        print(rpc("pool_list"))
+    except TargetdError as e:
+        print("Got error %d %s" % (e.error, e))


### PR DESCRIPTION
Add more comprehensive unit tests.  The combination of this test and the existing `client` and libStorageMgmt test shows fairly good code coverage.

Notes:

* Unit test uses `unittest` so we get all the features it provides
  * Test names have `_ep_` for error path tests `_gp_` for good path, using `-k ` allows selecting either and as always you can run individual tests
* Test are run over SSL, just as end users should be using service
* `test/test.sh` has `[setup|teardown]` arguments which can be useful for local development
* running `python3-coverage html` is useful for local development with detailed information about code paths
* Signal handling has been improved
* Some error paths removed, some added in service
* Additional unit tests can certainly be added
