### PR TITLE
Fix tiny regex issue

### DIFF
--- a/targetd/nfs.py
+++ b/targetd/nfs.py
@@ -68,7 +68,7 @@ class Export(object):
         anongid=int,
         sec=str)
 
-    export_regex = '([\/a-zA-Z0-9\.-_]+)[\s]+(.+)\((.+)\)'
+    export_regex = r"([\/a-zA-Z0-9\.\-_]+)[\s]+(.+)\((.+)\)"
     octal_nums_regex = r"""\\([0-7][0-7][0-7])"""
 
     @staticmethod


### PR DESCRIPTION
Range was likely not intended in this location as `.` till `_` also includes a-zA-Z and a bunch more, so it has to be escaped. Additionally, it's better to use a raw string as the \ only escapes regex parts.