### PR TITLE
Fix forgotten % in nfs export to remove not found

### DIFF
--- a/targetd/fs.py
+++ b/targetd/fs.py
@@ -238,5 +238,5 @@ def nfs_export_remove(req, host, path):
 
     if not found:
         raise TargetdError(TargetdError.NOT_FOUND_NFS_EXPORT,
-                           "NFS export to remove not found %s:%s",
+                           "NFS export to remove not found %s:%s" %
                            (host, path))


### PR DESCRIPTION
Due to the missing %, the client sees the raw `%s:%s` reference which is not ideal