### PR TITLE
Close the thread pool

### DIFF
--- a/test/targetd_test.py
+++ b/test/targetd_test.py
@@ -157,6 +157,8 @@ class TestConnect(unittest.TestCase):
         diff = end - start
         self.assertTrue((diff > 1 or diff < 3), "Not expected %s" % (str(diff)))
 
+        pool.close()
+
     def test_ep_bad_path(self):
 
         existing = testlib.rpc_path


### PR DESCRIPTION
We are getting a warning on fedora 32 that the pool had not been
freed up.

Signed-off-by: Tony Asleson <tasleson@redhat.com>