### PR TITLE
block: add size as a parameter to vol_copy

### DIFF
--- a/API.md
+++ b/API.md
@@ -62,7 +62,7 @@ the same name is created.
 Creates a new volume named `vol_new` in `pool` the same size as
 `vol_orig` in `pool`, and copies the contents from `vol_orig` into
 `vol_new`. `vol_orig` and `vol_new` will have differing UUIDs.
-Resize a new volume if set `size` after created.  
+Resize a new volume if set `size` after created (optional).  
 
 Export operations
 -----------------

--- a/API.md
+++ b/API.md
@@ -57,11 +57,12 @@ Removes `name` volume from pool `pool`. This destroys the backing
 data, and the data in the volume is lost even if another volume with
 the same name is created.
 
-### vol_copy(pool, vol_orig, vol_new)
+### vol_copy(pool, vol_orig, vol_new, size)
 
 Creates a new volume named `vol_new` in `pool` the same size as
 `vol_orig` in `pool`, and copies the contents from `vol_orig` into
 `vol_new`. `vol_orig` and `vol_new` will have differing UUIDs.
+Resize a new volume if set `size` after created.  
 
 Export operations
 -----------------

--- a/client
+++ b/client
@@ -129,7 +129,7 @@ for pool in pools:
 
         try:
             jsonrequest("vol_copy",
-                        dict(pool=pool, vol_orig="test2", vol_new="test2-copy", size=8*1024*1024))
+                        dict(pool=pool, vol_orig="test2", vol_new="test2-copy"))
 
             try:
                 jsonrequest("export_create",
@@ -160,6 +160,13 @@ for pool in pools:
 
         finally:
             jsonrequest("vol_destroy", dict(pool=pool, name="test2-copy"))
+
+        try:
+            jsonrequest("vol_copy",
+                        dict(pool=pool, vol_orig="test2", vol_new="test2-copy-resize", size=8*1024*1024))
+
+        finally:
+            jsonrequest("vol_destroy", dict(pool=pool, name="test2-copy-resize"))
 
     finally:
         jsonrequest("vol_destroy", dict(pool=pool, name="test2"))

--- a/client
+++ b/client
@@ -129,7 +129,7 @@ for pool in pools:
 
         try:
             jsonrequest("vol_copy",
-                        dict(pool=pool, vol_orig="test2", vol_new="test2-copy"))
+                        dict(pool=pool, vol_orig="test2", vol_new="test2-copy", size=8*1024*1024))
 
             try:
                 jsonrequest("export_create",

--- a/targetd/backends/lvm.py
+++ b/targetd/backends/lvm.py
@@ -199,7 +199,7 @@ def destroy(req, pool, name):
     bd.lvm.lvremove(vg_name, name)
 
 
-def copy(req, pool, vol_orig, vol_new, timeout=10):
+def copy(req, pool, vol_orig, vol_new, size, timeout=10):
     """
     Create a new volume that is a copy of an existing one.
     Since 0.6, requires thinp support.
@@ -219,6 +219,14 @@ def copy(req, pool, vol_orig, vol_new, timeout=10):
         raise TargetdError(TargetdError.UNEXPECTED_EXIT_CODE,
                            "Failed to copy volume, "
                            "nested error: {}".format(str(err).strip()))
+
+    if size is not None:
+        try:
+            bd.lvm.lvresize(vg_name, vol_new, size)
+        except bd.LVMError as err:
+            raise TargetdError(TargetdError.UNEXPECTED_EXIT_CODE,
+                               "Failed to resize volume, "
+                               "nested error: {}".format(str(err).strip()))
 
 
 def vol_info(pool, name):

--- a/targetd/block.py
+++ b/targetd/block.py
@@ -162,12 +162,12 @@ def destroy(req, pool, name):
     mod.destroy(req, pool, name)
 
 
-def copy(req, pool, vol_orig, vol_new, timeout=10):
+def copy(req, pool, vol_orig, vol_new, size=None, timeout=10):
     mod = pool_module(pool)
     if not check_vol_exists(req, pool, vol_orig):
         raise TargetdError(TargetdError.NOT_FOUND_VOLUME,
                            "Volume %s not found in pool %s" % (vol_orig, pool))
-    mod.copy(req, pool, vol_orig, vol_new, timeout)
+    mod.copy(req, pool, vol_orig, vol_new, size, timeout)
 
 
 def export_list(req):

--- a/targetd/block.py
+++ b/targetd/block.py
@@ -170,12 +170,11 @@ def copy(req, pool, vol_orig, vol_new, size=None, timeout=10):
 
     if size is not None:
         for v in mod.volumes(req, pool):
-            if v['name'] == vol_orig and v['size'] > size:
+            if v['name'] == vol_orig and v['size'] >= size:
                 raise TargetdError(TargetdError.INVALID,
                                    "Size %d need a larger than size in original volume %s in pool %s" % (size,
                                                                                                          vol_orig,
                                                                                                          pool))
-
 
     mod.copy(req, pool, vol_orig, vol_new, size, timeout)
 

--- a/targetd/block.py
+++ b/targetd/block.py
@@ -167,6 +167,16 @@ def copy(req, pool, vol_orig, vol_new, size=None, timeout=10):
     if not check_vol_exists(req, pool, vol_orig):
         raise TargetdError(TargetdError.NOT_FOUND_VOLUME,
                            "Volume %s not found in pool %s" % (vol_orig, pool))
+
+    if size is not None:
+        for v in mod.volumes(req, pool):
+            if v['name'] == vol_orig and v['size'] > size:
+                raise TargetdError(TargetdError.INVALID,
+                                   "Size %d need a larger than size in original volume %s in pool %s" % (size,
+                                                                                                         vol_orig,
+                                                                                                         pool))
+
+
     mod.copy(req, pool, vol_orig, vol_new, size, timeout)
 
 

--- a/test/lsm_test.sh
+++ b/test/lsm_test.sh
@@ -37,7 +37,7 @@ if [ $FEDORA -eq 0 ]; then
     ln -s `pwd`/plugin `pwd`/python_binding/lsm/plugin  || exit 1
     ln -s `pwd`/tools/lsmcli `pwd`/python_binding/lsm || exit 1
     ln -s `pwd`/python_binding/lsm/.libs/*.so `pwd`/python_binding/lsm/. || exit 1
-    ln -s `pwd`/plugin/nfs/.libs/*.so `pwd`/plugin/nfs/. || exit 1
+    ln -s `pwd`/plugin/nfs_plugin/.libs/*.so `pwd`/plugin/nfs_plugin/. || exit 1
 
     # Make the IPC directory
     mkdir -p /var/run/lsm/ipc || exit 1

--- a/test/lsm_test.sh
+++ b/test/lsm_test.sh
@@ -41,7 +41,7 @@ if [ $FEDORA -eq 0 ]; then
 
     # Make the IPC directory
     mkdir -p /var/run/lsm/ipc || exit 1
-    PYENV=`pwd`/python_binding
+    PYENV=`pwd`/python_binding:`pwd`/plugin
     LSMDLOG=/tmp/lsmd.log
 
     # Start up the daemon

--- a/test/targetd_test.py
+++ b/test/targetd_test.py
@@ -520,7 +520,7 @@ class TestTargetd(unittest.TestCase):
             vol.name = vol_name
             self._vol_destroy(block_pool, vol)
 
-    def test_ep_copy_expand_volume(self):
+    def test_gp_copy_expand_volume(self):
         for block_pool in self._block_pools():
             vol_name = rs(length=6)
             vol_copy_name = vol_name + "_copy"
@@ -535,6 +535,40 @@ class TestTargetd(unittest.TestCase):
 
             vol_copy.name = vol_copy_name
             self._vol_destroy(block_pool, vol_copy)
+            vol.name = vol_name
+            self._vol_destroy(block_pool, vol)
+
+    def test_ep_same_size_volume(self):
+        for block_pool in self._block_pools():
+            vol_name = rs(length=6)
+            vol_copy_name = vol_name + "_copy"
+            vol = TestTargetd._vol_create(block_pool, vol_name)
+
+            error_code = 0
+            try:
+                TestTargetd._vol_copy(block_pool, vol, vol_copy_name, vol.size)
+            except TargetdError as e:
+                error_code = e.error
+            self.assertEqual(error_code, TargetdError.INVALID)
+
+            vol.name = vol_name
+            self._vol_destroy(block_pool, vol)
+
+    def test_ep_shrink_size_volume(self):
+        for block_pool in self._block_pools():
+            vol_name = rs(length=6)
+            vol_copy_name = vol_name + "_copy"
+            vol = TestTargetd._vol_create(block_pool, vol_name)
+
+            shrink_size = vol.size / 2
+
+            error_code = 0
+            try:
+                TestTargetd._vol_copy(block_pool, vol, vol_copy_name, shrink_size)
+            except TargetdError as e:
+                error_code = e.error
+            self.assertEqual(error_code, TargetdError.INVALID)
+
             vol.name = vol_name
             self._vol_destroy(block_pool, vol)
 

--- a/test/targetd_test.py
+++ b/test/targetd_test.py
@@ -527,7 +527,7 @@ class TestTargetd(unittest.TestCase):
 
             vol = TestTargetd._vol_create(block_pool, vol_name)
 
-            expanded_size = 200 * 1024 * 1024 * 1024
+            expanded_size = vol.size + 200 * 1024 * 1024
             TestTargetd._vol_copy(block_pool, vol, vol_copy_name, expanded_size)
 
             vol_copy = TestTargetd._vol_list(block_pool, vol_copy_name)[0]


### PR DESCRIPTION
## Change
-  add the `size` parameter to `vol_copy`.

call expand commands after call clone/snapshot volume.

## Background
Now, the `vol_new` created volume size is the same as `vol_orig`. but some cases need to expand `vol_new`.

For example, the OS image. 
`vol_orig` is a base image. size is about 10MB to 500MB. (in Fedora 33 Cloud Base Images is 319MB in qcow2.)[1]
`vol_new` is a volume of the virtual machines. need size is about 1GB too unlimited. It is bigger than the size of `vol_orig`.

So, need `size` parameter in `vol_copy`.

[1]: https://alt.fedoraproject.org/cloud/