### PR TITLE
Allow running with both libblockdev 3.0 and 2.0 API

### DIFF
--- a/targetd/backends/lvm.py
+++ b/targetd/backends/lvm.py
@@ -18,17 +18,22 @@
 import gi
 
 gi.require_version("GLib", "2.0")
-gi.require_version("BlockDev", "2.0")
-
 from gi.repository import GLib
-from gi.repository import BlockDev as bd
+
+try:
+    gi.require_version("BlockDev", "3.0")
+    from gi.repository import BlockDev as bd
+except ValueError:
+    gi.require_version("BlockDev", "2.0")
+    from gi.repository import BlockDev as bd
+
+    bd.switch_init_checks(False)
+
 from targetd.main import TargetdError
 
 REQUESTED_PLUGIN_NAMES = {"lvm"}
 
 requested_plugins = bd.plugin_specs_from_names(REQUESTED_PLUGIN_NAMES)
-
-bd.switch_init_checks(False)
 
 pools = []
 vg_name_2_pool_name_dict = {}


### PR DESCRIPTION
The only API change in libblockdev 3.0 affecting targetd is the removal of bd_switch_init_checks function. Dependency checking is now disabled during initialization by defautl so removing this call with 3.0 does not change the behaviour.