### PR TITLE
fix: only call wrap_socket when TLS is enabled

### DIFF
--- a/targetd/main.py
+++ b/targetd/main.py
@@ -346,7 +346,10 @@ def main():
         note = "(TLS no)"
 
     server = server_class(("", 18700), TargetHandler)
-    server.socket = wrap_socket(server.socket)
+
+    if config["ssl"]:
+        server.socket = wrap_socket(server.socket)
+
     log.info("started server %s", note)
 
     server.timeout = 0.5


### PR DESCRIPTION
Changes introduced in https://github.com/open-iscsi/targetd/pull/99 break targetd with `ssl: false` set.